### PR TITLE
use correct framework

### DIFF
--- a/src/Nooptime.Domain/Nooptime.Domain.csproj
+++ b/src/Nooptime.Domain/Nooptime.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/src/Nooptime.Tests/Nooptime.Tests.csproj
+++ b/src/Nooptime.Tests/Nooptime.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Nooptime.Tests</AssemblyName>
     <RootNamespace>Nooptime.Tests</RootNamespace>

--- a/src/Nooptime.Web/Nooptime.Web.csproj
+++ b/src/Nooptime.Web/Nooptime.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)